### PR TITLE
pin Werkzeug version to < 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
   postgresql: "9.5"
   apt:
     packages:
-    - postgresql-9.5-postgis-2.3
+    - postgresql-9.5-postgis-2.4
 
 before_install:
   - sudo apt-get update

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ gunicorn==19.7.1
 flask-cors==3.0.3
 gevent==1.3.5
 git+https://github.com/timmccauley/imposm-parser.git@python3
+werkzeug>=0.15,<1.0


### PR DESCRIPTION
fixes #73
I wonder how Travis worked then actually.. Talking about it, I'll do another PR to include 3.7 & 3.8 in `travis.yml`.