### PR TITLE
Change pbf processor to osmium

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,11 +2,14 @@
 
 import unittest
 from flask.cli import FlaskGroup
-from openpoiservice.server import create_app, db
-from openpoiservice.server.db_import import parser
 import os
 import sys
+from pathlib import Path
 import logging
+
+from openpoiservice.server import create_app, db, ops_settings
+from openpoiservice.server.db_import import parser
+
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -48,12 +51,11 @@ def import_data():
     osm_dir = os.getcwd() + '/osm'
 
     for dirName, subdirList, fileList in os.walk(osm_dir):
-        print('Found directory: %s' % dirName)
         for fname in fileList:
-            if fname.endswith('.osm.pbf') or fname.endswith('.osm'):
-                osm_files.append(os.path.join(dirName, fname))
+            if fname.endswith('.osm') or fname.endswith('.pbf'):
+                osm_files.append(Path(os.path.join(dirName, fname)))
 
-    logger.info("Starting to import OSM data...{}".format(osm_files))
+    logger.info('Starting to import OSM data from\n\t{}'.format("\n\t".join([p.name for p in osm_files])))
     parser.run_import(osm_files)
 
 

--- a/openpoiservice/server/categories/categories.py
+++ b/openpoiservice/server/categories/categories.py
@@ -81,7 +81,9 @@ class CategoryTools(object):
 
         if bool(tags):
 
-            for tag_name, tag_value in tags.items():
+            for tag in tags:
+                tag_name = tag.k
+                tag_value = tag.v
 
                 if tag_name:
 

--- a/openpoiservice/server/config.py
+++ b/openpoiservice/server/config.py
@@ -29,7 +29,10 @@ class ProductionConfig(BaseConfig):
 class DevelopmentConfig(BaseConfig):
     """Production configuration."""
 
-    SQLALCHEMY_DATABASE_URI = 'postgresql://gis_admin:admin@localhost:5433/gis'
+    # SQLALCHEMY_DATABASE_URI = 'postgresql://gis_admin:admin@localhost:5433/gis'
+    SQLALCHEMY_DATABASE_URI = 'postgresql://{}:{}@{}:{}/{}'.format(pg_settings['user_name'], pg_settings['password'],
+                                                                   pg_settings['host'], pg_settings['port'],
+                                                                   pg_settings['db_name'])
     DEBUG_TB_ENABLED = True
     SQLALCHEMY_TRACK_MODIFICATIONS = True
 

--- a/openpoiservice/server/db_import/osm_reader.py
+++ b/openpoiservice/server/db_import/osm_reader.py
@@ -1,0 +1,156 @@
+import osmium
+from shapely import wkb as wkblib, geometry
+import logging
+import uuid
+from copy import deepcopy
+
+from openpoiservice.server import categories_tools, ops_settings, db
+from openpoiservice.server.db_import.models import Pois, Tags, Categories
+from openpoiservice.server.db_import.objects import PoiObject, TagsObject
+
+wkb_fac = osmium.geom.WKBFactory()
+wkt_fac = osmium.geom.WKTFactory()
+logger = logging.getLogger(__name__)
+
+# TODO: Use logic to pick best memory option based on
+class OsmReader(osmium.SimpleHandler):
+    """Let's see where this leads.."""
+
+    def __init__(self):
+        super().__init__()
+        self._poi_objects = list()
+        self._tag_objects = list()
+        self._cat_objects = list()
+
+        # Counters
+        self.poi_count = 0
+
+    @staticmethod
+    def extract_tags(tags):
+        """
+        Takes a :class:`osmium.osm.TagList` object and returns as dict
+
+        :param tags: The tags returned from osmium.
+        :type tags: osmium.osm.TagList
+
+        :rtype: dict
+        """
+        tags_dict = dict()
+        for tag in tags:
+            tags_dict[tag.k] = tag.v
+        return tags_dict
+
+    def node(self, obj_node):
+        """
+        Call back for :class:`osmium.osm.Node` parser.
+
+        :param obj_node: The node currently processed.
+        :type obj_node: osmium.osm.Node
+        """
+        cat_included = categories_tools.get_category(obj_node.tags)
+        if cat_included:
+            osmid = deepcopy(obj_node.id)
+            tags = self.extract_tags(obj_node.tags)
+            location = wkt_fac.create_point(obj_node.location)
+
+            self.store_objects(
+                osmid=osmid,
+                tags=tags,
+                location=location,
+                osm_type=1,
+                categories=cat_included
+            )
+
+    def area(self, obj_area):
+        """
+        Callback for :class:`osmium.osm.Area` parser
+
+        :param obj_area: The current area being processed.
+        :type obj_area: osmium.osm.Area
+        """
+        cat_included = categories_tools.get_category(obj_area.tags)
+        if cat_included:
+            if obj_area.from_way():
+                osm_type = 2
+            else:
+                osm_type = 3
+
+            osmid = deepcopy(obj_area.id)
+            tags = self.extract_tags(obj_area.tags)
+            # Determine centroid
+            # TODO: import whole polygons, maybe simplified
+            wkb_area = wkb_fac.create_multipolygon(obj_area)
+            geom_multipolygon = wkblib.loads(wkb_area, hex=True)
+
+            for poly in geom_multipolygon:
+                self.store_objects(
+                    osmid=osmid,
+                    tags=tags,
+                    location=poly.centroid.wkt,
+                    osm_type=osm_type,
+                    categories=cat_included
+                )
+
+        pass
+
+    def store_objects(self, osmid, tags, location, osm_type, categories):
+        """
+        Creates the model objects and saves them periodically.
+
+        :type osmid: int
+        :type tags: dict
+        :type location: list|tuple[int]
+        :type osm_type: int
+
+        :param categories: The valid categories for each POI
+        :type categories: list
+        """
+        self.poi_count += 1
+        # TODO: get rid of uuid, seems pointless as PK (which is not even true other than the OSM object table)
+        # random id used as primary key
+        uid = uuid.uuid4().bytes
+
+        # Create and store tags dynamically from settings yml
+        # TODO: since tags table is 1:1 with OSM objects, this doesn't have to be its own table
+        # consider putting it in a JSON column instead in the OSM object table
+        for tag_key, tag_value in tags.items():
+            if tag_key in ops_settings['column_mappings']:
+                self._tag_objects.append(Tags(
+                    uuid=uid,
+                    osm_id=osmid,
+                    key=tag_key,
+                    value=tag_value
+                ))
+
+        # Create POI object
+        self._poi_objects.append(Pois(
+            uuid=uid,
+            osm_id=osmid,
+            osm_type=osm_type,
+            geom=location
+        ))
+
+        # Create categories
+        # TODO: Categories should only be stored once. Now it's creating a quadrillion useless copies
+        for category in categories:
+            self._cat_objects.append(Categories(
+                uuid=uid,
+                category=category
+            ))
+
+        # periodically dump the objects in the DB
+        if len(self._poi_objects) % 10000 == 0:
+            logger.info(f"Saved {len(self._poi_objects)} POIs")
+            self.save_objects()
+
+    def save_objects(self):
+        """
+        Saves the objects in the DB.
+        """
+        db.session.add_all(self._poi_objects)
+        db.session.add_all(self._cat_objects)
+        db.session.add_all(self._tag_objects)
+        db.session.commit()
+        self._poi_objects.clear()
+        self._tag_objects.clear()
+        self._cat_objects.clear()

--- a/openpoiservice/server/db_import/parser.py
+++ b/openpoiservice/server/db_import/parser.py
@@ -1,89 +1,41 @@
 # openpoiservice/server/parser.py
+import logging
+from pathlib import Path
+import multiprocessing as mp
 
 from .osm_reader import OsmReader
-from openpoiservice.server.db_import.parse_osm import OsmImporter
-from openpoiservice.server.utils.decorators import timeit, processify
 from openpoiservice.server import ops_settings
-from imposm.parser import OSMParser
-import logging
-import time
-
-# from guppy import hpy
-from collections import deque
+from openpoiservice.server.utils.decorators import timeit
 
 # h = hpy()
 logger = logging.getLogger(__name__)
 
-
-# process this function to free memory after import of each osm file
-
-# def parse_import(osm_file):
-#     logger.info('Starting to read {}'.format(osm_file))
-#
-#     osm_importer = OsmImporter()
-#
-#     logger.info('Parsing and importing nodes...')
-#     nodes = OSMParser(concurrency=ops_settings['concurrent_workers'], nodes_callback=osm_importer.parse_nodes)
-#     nodes.parse(osm_file)
-#
-#     logger.info('Parsing relations...')
-#     relations = OSMParser(concurrency=ops_settings['concurrent_workers'],
-#                           relations_callback=osm_importer.parse_relations)
-#     relations.parse(osm_file)
-#     logger.info('Found {} ways in relations'.format(osm_importer.relations_cnt))
-#
-#     logger.info('Parsing ways...')
-#     ways = OSMParser(concurrency=ops_settings['concurrent_workers'], ways_callback=osm_importer.parse_ways)
-#     ways.parse(osm_file)
-#
-#     logger.info('Found {} ways'.format(osm_importer.ways_cnt))
-#     del osm_importer.relation_ways
-#
-#     # Sort the ways by the first osm_id reference, saves memory for parsing coords
-#     osm_importer.process_ways.sort(key=lambda x: x.refs[0])
-#     # init self.process_ways_length before the first call of parse_coords function!
-#     osm_importer.process_ways_length = len(osm_importer.process_ways)
-#
-#     # https://docs.python.org/3/library/collections.html#collections.deque
-#     osm_importer.process_ways = deque(osm_importer.process_ways)
-#     logger.info('Importing ways... (note this wont work concurrently)')
-#
-#     coords = OSMParser(concurrency=1, coords_callback=osm_importer.parse_coords_for_ways)
-#     coords.parse(osm_file)
-#
-#     logger.info('Storing remaining pois')
-#     osm_importer.save_remainder()
-#
-#     logger.info('Found {} pois'.format(osm_importer.pois_cnt))
-#
-#     logger.info('Finished import of {}'.format(osm_file))
-#
-#     # logger.debug('Heap: {}'.format(h.heap()))
-#
-#     # clear memory
-#     del osm_importer
-
-
 def parse_import(osm_file):
-    reader = OsmReader()
+    """
+    Runs a process.
 
-    logger.info(f"Starting with file {osm_file}...")
-    reader.apply_file(osm_file, locations=True, idx='sparse_mmap_array')
+    :param osm_file: the OSM file path
+    :type osm_file: Path
+    """
+    reader = OsmReader(osm_file.name)
 
-    logger.info(f"Found {reader.poi_count} POIs")
+    logger.info(f"Starting with file {osm_file.name}...")
+    reader.apply_file(str(osm_file.resolve()), locations=True, idx='sparse_mmap_array')
+
+    logger.info(f"{osm_file.name}: Found {reader.poi_count} POIs")
 
     # Save whatever's left in the object lists
     reader.save_objects()
 
-
-@processify
-def parse_file(osm_file):
-    parse_import(osm_file)
+    return reader.poi_count
 
 
 @timeit
 def run_import(osm_files_to_import):
+    pool = mp.Pool(ops_settings['concurrent_workers'])
+    poi_counts = pool.map(parse_import, osm_files_to_import)
 
-    for osm_file in osm_files_to_import:
+    pool.close()
+    pool.join()
 
-        parse_file(osm_file)
+    logger.info(f"Finished with total {sum(poi_counts)} POIs")

--- a/openpoiservice/server/db_import/parser.py
+++ b/openpoiservice/server/db_import/parser.py
@@ -1,5 +1,6 @@
 # openpoiservice/server/parser.py
 
+from .osm_reader import OsmReader
 from openpoiservice.server.db_import.parse_osm import OsmImporter
 from openpoiservice.server.utils.decorators import timeit, processify
 from openpoiservice.server import ops_settings
@@ -16,51 +17,63 @@ logger = logging.getLogger(__name__)
 
 # process this function to free memory after import of each osm file
 
+# def parse_import(osm_file):
+#     logger.info('Starting to read {}'.format(osm_file))
+#
+#     osm_importer = OsmImporter()
+#
+#     logger.info('Parsing and importing nodes...')
+#     nodes = OSMParser(concurrency=ops_settings['concurrent_workers'], nodes_callback=osm_importer.parse_nodes)
+#     nodes.parse(osm_file)
+#
+#     logger.info('Parsing relations...')
+#     relations = OSMParser(concurrency=ops_settings['concurrent_workers'],
+#                           relations_callback=osm_importer.parse_relations)
+#     relations.parse(osm_file)
+#     logger.info('Found {} ways in relations'.format(osm_importer.relations_cnt))
+#
+#     logger.info('Parsing ways...')
+#     ways = OSMParser(concurrency=ops_settings['concurrent_workers'], ways_callback=osm_importer.parse_ways)
+#     ways.parse(osm_file)
+#
+#     logger.info('Found {} ways'.format(osm_importer.ways_cnt))
+#     del osm_importer.relation_ways
+#
+#     # Sort the ways by the first osm_id reference, saves memory for parsing coords
+#     osm_importer.process_ways.sort(key=lambda x: x.refs[0])
+#     # init self.process_ways_length before the first call of parse_coords function!
+#     osm_importer.process_ways_length = len(osm_importer.process_ways)
+#
+#     # https://docs.python.org/3/library/collections.html#collections.deque
+#     osm_importer.process_ways = deque(osm_importer.process_ways)
+#     logger.info('Importing ways... (note this wont work concurrently)')
+#
+#     coords = OSMParser(concurrency=1, coords_callback=osm_importer.parse_coords_for_ways)
+#     coords.parse(osm_file)
+#
+#     logger.info('Storing remaining pois')
+#     osm_importer.save_remainder()
+#
+#     logger.info('Found {} pois'.format(osm_importer.pois_cnt))
+#
+#     logger.info('Finished import of {}'.format(osm_file))
+#
+#     # logger.debug('Heap: {}'.format(h.heap()))
+#
+#     # clear memory
+#     del osm_importer
+
+
 def parse_import(osm_file):
-    logger.info('Starting to read {}'.format(osm_file))
+    reader = OsmReader()
 
-    osm_importer = OsmImporter()
+    logger.info(f"Starting with file {osm_file}...")
+    reader.apply_file(osm_file, locations=True, idx='sparse_mmap_array')
 
-    logger.info('Parsing and importing nodes...')
-    nodes = OSMParser(concurrency=ops_settings['concurrent_workers'], nodes_callback=osm_importer.parse_nodes)
-    nodes.parse(osm_file)
+    logger.info(f"Found {reader.poi_count} POIs")
 
-    logger.info('Parsing relations...')
-    relations = OSMParser(concurrency=ops_settings['concurrent_workers'],
-                          relations_callback=osm_importer.parse_relations)
-    relations.parse(osm_file)
-    logger.info('Found {} ways in relations'.format(osm_importer.relations_cnt))
-
-    logger.info('Parsing ways...')
-    ways = OSMParser(concurrency=ops_settings['concurrent_workers'], ways_callback=osm_importer.parse_ways)
-    ways.parse(osm_file)
-
-    logger.info('Found {} ways'.format(osm_importer.ways_cnt))
-    del osm_importer.relation_ways
-
-    # Sort the ways by the first osm_id reference, saves memory for parsing coords
-    osm_importer.process_ways.sort(key=lambda x: x.refs[0])
-    # init self.process_ways_length before the first call of parse_coords function!
-    osm_importer.process_ways_length = len(osm_importer.process_ways)
-
-    # https://docs.python.org/3/library/collections.html#collections.deque
-    osm_importer.process_ways = deque(osm_importer.process_ways)
-    logger.info('Importing ways... (note this wont work concurrently)')
-
-    coords = OSMParser(concurrency=1, coords_callback=osm_importer.parse_coords_for_ways)
-    coords.parse(osm_file)
-
-    logger.info('Storing remaining pois')
-    osm_importer.save_remainder()
-
-    logger.info('Found {} pois'.format(osm_importer.pois_cnt))
-
-    logger.info('Finished import of {}'.format(osm_file))
-
-    # logger.debug('Heap: {}'.format(h.heap()))
-
-    # clear memory
-    del osm_importer
+    # Save whatever's left in the object lists
+    reader.save_objects()
 
 
 @processify

--- a/openpoiservice/server/ops_settings.yml
+++ b/openpoiservice/server/ops_settings.yml
@@ -1,5 +1,7 @@
 --- 
 attribution: "openrouteservice.org | OpenStreetMap contributors"
+osmium_strategy: flex_mem  # see osmium settings here: https://osmcode.org/osmium-concepts/#list-of-map-index-classes
+concurrent_workers: 3  # recommended: available cores - 1
 maximum_categories: 5
 # meters
 maximum_search_radius_for_linestrings: 2000
@@ -11,18 +13,15 @@ maximum_area: 50000000
 maximum_linestring_length: 500000
 # limit of pois
 response_limit: 2000
-# amount of workers used for parsing the osm files
-concurrent_workers: 4
 # Database parameters
 provider_parameters:
   table_name: ops_planet_pois
   db_name: gis
-  user_name: gis_admin
+  user_name: admin
   table_schema: public
-  #user_name: admin
   password: admin
   host: localhost
-  port: 5434
+  port: 5432
   port_tests: 5432
 # add any additional tags you want to save to the database
 column_mappings:

--- a/openpoiservice/server/ops_settings.yml
+++ b/openpoiservice/server/ops_settings.yml
@@ -17,7 +17,7 @@ response_limit: 2000
 provider_parameters:
   table_name: ops_planet_pois
   db_name: gis
-  user_name: admin
+  user_name: gis_admin
   table_schema: public
   password: admin
   host: localhost

--- a/openpoiservice/server/utils/decorators.py
+++ b/openpoiservice/server/utils/decorators.py
@@ -7,96 +7,8 @@ import functools
 import os
 import sys
 import inspect
-import traceback
-from functools import wraps
-from multiprocessing import Process, Queue
 
 logger = logging.getLogger(__name__)
-
-
-def processify(func):
-    """Decorator to run a function as a process.
-    Be sure that every argument and the return value
-    is *pickable*.
-    The created process is joined, so the code does not
-    run in parallel."""
-
-    def process_func(q, *args, **kwargs):
-        try:
-            ret = func(*args, **kwargs)
-        except Exception:
-            ex_type, ex_value, tb = sys.exc_info()
-            error = ex_type, ex_value, ''.join(traceback.format_tb(tb))
-            ret = None
-        else:
-            error = None
-
-        q.put((ret, error))
-
-    # register original function with different name
-    # in sys.modules so it is pickable
-    process_func.__name__ = func.__name__ + 'processify_func'
-    setattr(sys.modules[__name__], process_func.__name__, process_func)
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        q = Queue()
-        p = Process(target=process_func, args=[q] + list(args), kwargs=kwargs)
-        p.start()
-        ret, error = q.get()
-
-        if error:
-            ex_type, ex_value, tb_str = error
-            message = '%s (in subprocess)\n%s' % (ex_value.args, tb_str)
-            raise ex_type(message)
-
-        return ret
-
-    return wrapper
-
-
-def get_size(obj, seen=None):
-    """Recursively finds size of objects in bytes"""
-    size = sys.getsizeof(obj)
-    if seen is None:
-        seen = set()
-    obj_id = id(obj)
-    if obj_id in seen:
-        return 0
-    # Important mark as seen *before* entering recursion to gracefully handle
-    # self-referential objects
-    seen.add(obj_id)
-    if hasattr(obj, '__dict__'):
-        for cls in obj.__class__.__mro__:
-            if '__dict__' in cls.__dict__:
-                d = cls.__dict__['__dict__']
-                if inspect.isgetsetdescriptor(d) or inspect.ismemberdescriptor(d):
-                    size += get_size(obj.__dict__, seen)
-                break
-    if isinstance(obj, dict):
-        size += sum((get_size(v, seen) for v in obj.values()))
-        size += sum((get_size(k, seen) for k in obj.keys()))
-    elif hasattr(obj, '__iter__') and not isinstance(obj, (list, str, bytes, bytearray)):
-        size += sum((get_size(i, seen) for i in obj))
-    return size
-
-
-def profile(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        profiler = cProfile.Profile()
-        try:
-            profiler.enable()
-            ret = func(*args, **kwargs)
-            profiler.disable()
-            return ret
-        finally:
-            filename = os.path.expanduser(
-                os.path.join(os.getcwd(), func.__name__ + '.pstat')
-            )
-            profiler.dump_stats(filename)
-
-    return wrapper
 
 
 def timeit(method):
@@ -104,11 +16,7 @@ def timeit(method):
         ts = time.time()
         result = method(*args, **kw)
         te = time.time()
-        if 'log_time' in kw:
-            name = kw.get('log_name', method.__name__.upper())
-            kw['log_time'][name] = int((te - ts) * 1000)
-        else:
-            logger.info('%r  %2.2f ms' % (method.__name__, (te - ts) * 1000))
+        logger.info(f'{method.__name__} took {round((te - ts) * 1000, 2)} ms')
         return result
 
     return timed

--- a/openpoiservice/tests/base.py
+++ b/openpoiservice/tests/base.py
@@ -1,6 +1,7 @@
 # openpoiservice/server/tests/base.py
 
 from flask_testing import TestCase
+from pathlib import Path
 from openpoiservice.server import db, create_app
 from openpoiservice.server.db_import import parser
 import os
@@ -18,7 +19,7 @@ class BaseTestCase(TestCase):
     def setUp(self):
         db.create_all()
 
-        test_file = os.path.join(os.getcwd() + '/osm', 'bremen-tests.osm.pbf')
+        test_file = Path(os.path.join(os.getcwd() + '/osm', 'bremen-tests.osm.pbf'))
 
         parser.parse_import(test_file)
 

--- a/openpoiservice/tests/test_pois.py
+++ b/openpoiservice/tests/test_pois.py
@@ -142,7 +142,7 @@ class TestPoisBlueprint(BaseTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'features', response.data)
         data = json.loads(response.get_data(as_text=True))
-        self.assertEqual(len(data[0]['features']), 13)
+        self.assertEqual(len(data[0]['features']), 15)
 
     def test_request_poi_point_geom_with_bbox(self):
         response = self.client.post('/pois', data=json.dumps(request_poi_point_geom_with_bbox),
@@ -158,7 +158,7 @@ class TestPoisBlueprint(BaseTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'features', response.data)
         data = json.loads(response.get_data(as_text=True))
-        self.assertEqual(len(data[0]['features']), 7)
+        self.assertEqual(len(data[0]['features']), 8)
 
     def test_request_poi_polygon_geom_with_bbox(self):
         response = self.client.post('/pois', data=json.dumps(request_poi_polygon_geom_with_bbox),
@@ -166,7 +166,7 @@ class TestPoisBlueprint(BaseTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'features', response.data)
         data = json.loads(response.get_data(as_text=True))
-        self.assertEqual(len(data[0]['features']), 1)
+        self.assertEqual(len(data[0]['features']), 2)
 
     def test_request_poi_linestring_geom(self):
         response = self.client.post('/pois', data=json.dumps(request_poi_linestring_geom),

--- a/openpoiservice/tests/test_stats.py
+++ b/openpoiservice/tests/test_stats.py
@@ -51,7 +51,7 @@ class TestPoisBlueprint(BaseTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'places', response.data)
         data = json.loads(response.get_data(as_text=True))
-        self.assertEqual(data[0]['places']['total_count'], 9)
+        self.assertEqual(data[0]['places']['total_count'], 10)
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ scrapy==1.5.0
 gunicorn==19.7.1
 flask-cors==3.0.3
 gevent==1.3.5
-git+https://github.com/timmccauley/imposm-parser.git@python3
+osmium==2.15.4
 werkzeug>=0.15,<1.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setuptools.setup(
     author_email="timothy@openrouteservice.org",
     description="POI service consuming OpenStreetMap data",
     keywords='OSM ORS openrouteservice OpenStreetMap POI points of interest',
-    long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/GIScience/openpoiservice",
     packages=setuptools.find_packages(),

--- a/tests/test-pbf-processor.py
+++ b/tests/test-pbf-processor.py
@@ -1,0 +1,7 @@
+from openpoiservice.server.db_import.osm_reader import OsmReader
+
+r = OsmReader()
+r.apply_file('/home/nilsnolde/dev/python/openpoiservice/osm/bremen-tests.osm.pbf', locations=True, idx='sparse_mmap_array')
+
+print(r.areas)
+print(r.areas_from_line)


### PR DESCRIPTION
Fixes #80 

This will:
- remove `imposm`
- add `osmium` as dependency
- [`osmium` memory strategies](https://osmcode.org/osmium-concepts/#list-of-map-index-classes) are settable in `ops_config.yml`
- multiprocessing will thread one process per PBF file

Concurrency is now handled on a file basis, so single file imports are expected to be slightly slower than before. Multi-file import should be considerably faster