### PR TITLE
Optional prewarm logic to speed up initial queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ Best is to set up a `.env` file with the settings that need changing (e.g. `POST
 
 ##### PostgreSQL
 
-The PostgreSQL specific settings are the same as for Kartoza's excellent [PostGIS image](https://github.com/kartoza/docker-postgis):
+The PostgreSQL specific settings required to configure your database connection:
 
 - `POSTGRES_HOST`: The host for the PG installation. Can be a physical IP address or Docker container/service name if containers are linked in a network. Default `localhost`.
 - `POSTGRES_DBNAME`: The database name. Default `gis`.
 - `POSTGRES_PORT`: The PG published port. Default `5432`.
 - `POSTGRES_USER`: The PG user name. Default `gis_admin`.
 - `POSTGRES_PASS`: The PG password for the user name. Default `admin`.
+- `POSTGRES_PREWARM`: If you want to make use the prewarm module which will make sure your database I/O caches are filled up before the first query is made. Make sure that the `pg_prewarm` extension is enabled in your database by adding it to the shared preload libraries before setting this to `true`. Default `false`.
 
 ##### App
 

--- a/config_flask.py
+++ b/config_flask.py
@@ -16,8 +16,8 @@ class BaseConfig(object):
     POSTGRES_HOST = os.environ.get('POSTGRES_HOST', 'localhost')
     POSTGRES_DBNAME = os.environ.get('POSTGRES_DBNAME', 'gis')
     POSTGRES_PORT = int(os.environ.get('POSTGRES_PORT', '5432'))
-    POSTGRES_USER = os.environ.get('POSTGRES_USER', 'postgres')
-    POSTGRES_PASS = os.environ.get('POSTGRES_PASS', 'postgres')
+    POSTGRES_USER = os.environ.get('POSTGRES_USER', 'gis_admin')
+    POSTGRES_PASS = os.environ.get('POSTGRES_PASS', 'admin')
     POSTGRES_PREWARM = bool(strtobool(os.environ.get('POSTGRES_PREWARM', 'true')))
 
     # API settings

--- a/config_flask.py
+++ b/config_flask.py
@@ -16,9 +16,9 @@ class BaseConfig(object):
     POSTGRES_HOST = os.environ.get('POSTGRES_HOST', 'localhost')
     POSTGRES_DBNAME = os.environ.get('POSTGRES_DBNAME', 'gis')
     POSTGRES_PORT = int(os.environ.get('POSTGRES_PORT', '5432'))
-    POSTGRES_USER = os.environ.get('POSTGRES_USER', 'gis_admin')
-    POSTGRES_PASS = os.environ.get('POSTGRES_PASS', 'admin')
-    POSTGRES_PREWARM = bool(strtobool(os.environ.get('POSTGRES_PREWARM', 'false')))
+    POSTGRES_USER = os.environ.get('POSTGRES_USER', 'postgres')
+    POSTGRES_PASS = os.environ.get('POSTGRES_PASS', 'postgres')
+    POSTGRES_PREWARM = bool(strtobool(os.environ.get('POSTGRES_PREWARM', 'true')))
 
     # API settings
     OPS_LOGGING = os.environ.get('OPS_LOGGING', 'info')

--- a/config_flask.py
+++ b/config_flask.py
@@ -1,6 +1,7 @@
 # openpoiservice/server/config_flask.py
 
 import os
+from distutils.util import strtobool
 
 class BaseConfig(object):
     """Base configuration."""
@@ -17,6 +18,7 @@ class BaseConfig(object):
     POSTGRES_PORT = int(os.environ.get('POSTGRES_PORT', '5432'))
     POSTGRES_USER = os.environ.get('POSTGRES_USER', 'gis_admin')
     POSTGRES_PASS = os.environ.get('POSTGRES_PASS', 'admin')
+    POSTGRES_PREWARM = bool(strtobool(os.environ.get('POSTGRES_PREWARM', 'false')))
 
     # API settings
     OPS_LOGGING = os.environ.get('OPS_LOGGING', 'info')

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,7 @@
 # manage.py
 from sqlalchemy import MetaData
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import ProgrammingError
 
 import unittest
 import os
@@ -69,10 +70,14 @@ def import_data():
                 pass
         logger.info('Starting to prewarm tables {}'.format(", ".join(tables)))
         for tbl in tables:
-            sql = text("select pg_prewarm('{}')".format(tbl))
-            result = db.engine.execute(sql)
-            for res in result:
-                logger.info('Prewarmed {} pages in {}'.format(res, tbl))
+            try:
+                sql = text("select pg_prewarm('{}')".format(tbl))
+                result = db.engine.execute(sql)
+                for res in result:
+                    logger.info('Prewarmed {} pages in {}'.format(res, tbl))
+            except ProgrammingError as e:
+               logger.info("pg_prewarm is set to {} but it seems not to be enabled in the database.\n Proceeding without.".format(prewarm))
+               logger.debug(str(e.__dict__['orig']))
 
     sys.exit(0)
 

--- a/manage.py
+++ b/manage.py
@@ -61,7 +61,12 @@ def import_data():
 
     prewarm = app.config['POSTGRES_PREWARM']
     if not is_testing() and prewarm == True:
-        tables = ['ops_pois', 'ops_categories', 'ops_tags']
+        tables = []
+        for cls in db.Model._decl_class_registry.values():
+            try:
+                tables.append(cls.__tablename__)
+            except:
+                pass
         logger.info('Starting to prewarm tables {}'.format(", ".join(tables)))
         for tbl in tables:
             sql = text("select pg_prewarm('{}')".format(tbl))

--- a/openpoiservice/utils/osm_reader.py
+++ b/openpoiservice/utils/osm_reader.py
@@ -86,21 +86,22 @@ class OsmReader(osmium.SimpleHandler):
             tags = self.extract_tags(obj_area.tags)
             # Determine centroid
             # TODO: import whole polygons, maybe simplified
-            try:
-                wkb_area = wkb_fac.create_multipolygon(obj_area)
-                geom_multipolygon = wkblib.loads(wkb_area, hex=True)
 
-                for poly in geom_multipolygon:
-                    self.store_objects(
-                        osmid=osmid,
-                        tags=tags,
-                        location=poly.centroid.wkt,
-                        osm_type=osm_type,
-                        categories=cat_included
-                    )
-            except RuntimeError as e:
-                logger.info(e)
-        pass
+            # TODO: polygons with inner rings will fail to parse
+            # check if the polygon has inner rings and if this is the case
+            # just use the outer polygon moving forward
+            # see here: https://github.com/osmcode/libosmium/issues/225
+            wkb_area = wkb_fac.create_multipolygon(obj_area)
+            geom_multipolygon = wkblib.loads(wkb_area, hex=True)
+
+            for poly in geom_multipolygon:
+                self.store_objects(
+                    osmid=osmid,
+                    tags=tags,
+                    location=poly.centroid.wkt,
+                    osm_type=osm_type,
+                    categories=cat_included
+                )
 
     def store_objects(self, osmid, tags, location, osm_type, categories):
         """

--- a/openpoiservice/utils/osm_reader.py
+++ b/openpoiservice/utils/osm_reader.py
@@ -86,18 +86,20 @@ class OsmReader(osmium.SimpleHandler):
             tags = self.extract_tags(obj_area.tags)
             # Determine centroid
             # TODO: import whole polygons, maybe simplified
-            wkb_area = wkb_fac.create_multipolygon(obj_area)
-            geom_multipolygon = wkblib.loads(wkb_area, hex=True)
+            try:
+                wkb_area = wkb_fac.create_multipolygon(obj_area)
+                geom_multipolygon = wkblib.loads(wkb_area, hex=True)
 
-            for poly in geom_multipolygon:
-                self.store_objects(
-                    osmid=osmid,
-                    tags=tags,
-                    location=poly.centroid.wkt,
-                    osm_type=osm_type,
-                    categories=cat_included
-                )
-
+                for poly in geom_multipolygon:
+                    self.store_objects(
+                        osmid=osmid,
+                        tags=tags,
+                        location=poly.centroid.wkt,
+                        osm_type=osm_type,
+                        categories=cat_included
+                    )
+            except RuntimeError as e:
+                logger.info(e)
         pass
 
     def store_objects(self, osmid, tags, location, osm_type, categories):
@@ -161,3 +163,4 @@ class OsmReader(osmium.SimpleHandler):
         self._poi_objects.clear()
         self._tag_objects.clear()
         self._cat_objects.clear()
+


### PR DESCRIPTION
This PR adds logic to enable prewarming in postgres ([link2](https://www.cybertec-postgresql.com/en/prewarming-postgresql-i-o-caches/), [link3](https://blog.dbi-services.com/pre-warming-the-buffer-cache-in-postgresql/)) #95 .

Tested on Ubuntu 18.04 with PostgreSQL 11  and PostGIS 2.5.

Note 1: [auto-prewarming will only work from postgres11 onwards.](https://www.enterprisedb.com/blog/autoprewarm-new-functionality-pgprewarm)

Note 2: I can't get it working in the same way inside a Docker container (see https://github.com/kartoza/docker-postgis/issues/229). Let's keep this PR open until we know more about this.

Using `415430` POIs from

```
178M	minnesota-latest.osm.pbf
71M	mississippi-latest.osm.pbf
62M	montana-latest.osm.pbf
84M	new-mexico-latest.osm.pbf
64M	puerto-rico-latest.osm.pbf
```

As a test with a query such as 

```
\timing

SELECT count(*) FROM ops_pois p WHERE ST_Within(p.geom::geometry,ST_GeomFromGeoJSON('{"type":"Polygon","coordinates":[[[-106.5363109731028,35.151747622563988],[-106.532802489259481,35.118222110283412],[-106.556192381548257,35.119391604897856],[-106.590887388443278,35.133425540271119],[-106.56009069692972,35.159934084865064],[-106.552294066166795,35.145510317953651],[-106.543717772327582,35.139662844881457],[-106.5363109731028,35.151747622563988]]],"crs":{"type":"name","properties":{"name":"EPSG:4326"}}}'));
```

Will take about 350-400ms in the first initial query. Subsequent queries will be double the speed as the cache will be filled. Enabling prewarming will speed up the first initial query the same way. 

If you want to test, you can use this script to drop the caches and time the query.

```
#!/usr/bin/sudo bash

service postgresql stop
sync
echo 3 > /proc/sys/vm/drop_caches
service postgresql start
```