### PR TITLE
Updates 2021

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,5 +127,4 @@ ops_settings_docker*.yml
 !ops_settings_docker_standalone.yml
 docker-compose-*.yml
 !docker-compose-standalone.yml
-
 backup/*

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ ops_settings_docker*.yml
 !ops_settings_docker_standalone.yml
 docker-compose-*.yml
 !docker-compose-standalone.yml
+
+backup/*

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -3,5 +3,5 @@ bind = "0.0.0.0:5000"
 workers = 4
 worker_class = 'gevent'
 worker_connections = 1000
-timeout = 30
+timeout = 60
 keepalive = 2

--- a/openpoiservice/server/api/query_builder.py
+++ b/openpoiservice/server/api/query_builder.py
@@ -203,7 +203,7 @@ class QueryBuilder(object):
 
             places_dict["places"]["total_count"] += poi_group.count
 
-        logger.info('Number of poi stats groups: {}'.format(len(places_dict)))
+        logger.debug('Number of poi stats groups: {}'.format(len(places_dict)))
 
         return places_dict
 
@@ -262,6 +262,6 @@ class QueryBuilder(object):
 
         feature_collection = geojson.FeatureCollection(geojson_features, bbox=MultiPoint(lat_lngs).bounds)
 
-        logger.info("Amount of features {}".format(len(geojson_features)))
+        logger.debug("Amount of features {}".format(len(geojson_features)))
 
         return feature_collection

--- a/openpoiservice/server/api/views.py
+++ b/openpoiservice/server/api/views.py
@@ -1,5 +1,8 @@
 # openpoiservice/server/main/views.py
-
+import geojson
+import json
+import copy
+from datetime import datetime
 from flask import Blueprint, request, Response
 from openpoiservice.server import categories_tools
 from voluptuous import Schema, Required, Length, Range, Coerce, Any, All, MultipleInvalid, Optional, Boolean
@@ -8,9 +11,6 @@ from openpoiservice.server import api_exceptions, ops_settings
 from openpoiservice.server.api.query_builder import QueryBuilder
 from openpoiservice.server.utils.geometries import parse_geometry, validate_limit, GeomTransformer
 from openpoiservice.server.api.query_info import QueryInfo
-import geojson
-import json
-import copy
 
 
 GeomTransformer.init_transformer()
@@ -140,6 +140,11 @@ def places():
             return r
 
         else:
+            with open("osm/invalid-requests.log", "a") as f:
+                time = datetime.now()
+                req = request.data.decode().strip().replace("\n", "").replace(" ", "")
+                f.write(f"{time} {request.remote_addr}:{request.headers['Authorization']} - {req}\n")
+                f.close()
 
             raise api_exceptions.InvalidUsage(status_code=400, error_code=4009)
 

--- a/openpoiservice/server/db_import/parse_osm.py
+++ b/openpoiservice/server/db_import/parse_osm.py
@@ -302,6 +302,12 @@ class OsmImporter(object):
         If running in update mode, delete all POIs with IDs in buffer first. Foreign key constraints in the database
         handle deletion of related tags/categories.
         """
+
+        if not self.update_mode:
+            for poi in self.poi_objects:
+                if len(db.session.query(POIs).filter_by(osm_type=poi.osm_type, osm_id=poi.osm_id).all()) > 0:
+                    self.update_mode = True
+
         if self.update_mode:
             for poi in self.poi_objects:
                 db.session.query(POIs).filter_by(osm_type=poi.osm_type, osm_id=poi.osm_id).delete()


### PR DESCRIPTION
- don't write info messages for every request
- init process should try to ignore duplicate key errors and overwrite instead of postponing
- requests rejected due to missing content-type header should be logged since we were observing a ton of those, we need to find out where that's coming from 