### PR TITLE
Python base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,20 @@
-# gunicorn-flask
-
-# requires this ubuntu version due to protobuf library update
-FROM ubuntu:18.04
+FROM python:3.9-slim
 MAINTAINER Timothy Ellersiek <timothy@openrouteservice.org>
 
-RUN apt-get update && apt-get install -y python3-pip python-virtualenv nano wget git locales build-essential \
-protobuf-compiler=3.0.0-9.1ubuntu1 libprotobuf-dev=3.0.0-9.1ubuntu1
+# protobuf is required to parse osm files.
+# git to install imposm-parser via pip from github
+# build-essential to build imposm-parser
+RUN apt-get update && apt-get install -y libprotobuf-dev protobuf-compiler locales git build-essential
 
 # Set the locale
-RUN locale-gen en_US.UTF-8
-ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
+ENV LANG=C.UTF-8 LANGUAGE=C:en LC_ALL=C.UTF-8
 
 # Setup flask application
-COPY requirements.txt /deploy/app/requirements.txt
-RUN virtualenv --python=python3.6 /ops_venv && /bin/bash -c "source /ops_venv/bin/activate" && \
-/ops_venv/bin/pip3 install Cython && /ops_venv/bin/pip3 install -r /deploy/app/requirements.txt
-
-COPY gunicorn_config.py /deploy/gunicorn_config.py
-COPY run.sh manage.py /deploy/app/
-COPY openpoiservice /deploy/app/openpoiservice
-
 WORKDIR /deploy/app
+COPY requirements.txt ./
+RUN pip3 install -r /deploy/app/requirements.txt
+COPY gunicorn_config.py run.sh manage.py ./
+COPY openpoiservice ./openpoiservice
+
 EXPOSE 5000
-ENTRYPOINT ["/bin/bash", "/deploy/app/run.sh"]
+ENTRYPOINT ["/bin/bash", "run.sh"]

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Make your necessary changes to the settings in the file `ops_settings_docker.yml
 If you are planning to import a different osm file, please download it to the `osm folder` (any folder within will be scanned
 for osm files) as this will be a shared volume. 
 
-### Docker-compose
+### Docker Compose
 
 #### All-in-one docker image
 
@@ -89,7 +89,7 @@ Don't forget to change the host name and port inside `ops_settings_docker.yml` b
 Command to use to run all-in-one docker container
 
 ```sh
-docker-compose -f /path/to/docker-compose-with-postgis.yml up -d
+docker compose -f /path/to/docker-compose-with-postgis.yml up api -d
 ```
 
 #### Only deploy openpoiservice
@@ -97,7 +97,7 @@ docker-compose -f /path/to/docker-compose-with-postgis.yml up -d
 This will only run openpoiservice inside a container, meaning that you will need to handle the database yourself and connect it to this container.
 
 ```sh
-docker-compose -f /path/to/docker-compose.yml up -d
+docker compose -f /path/to/docker-compose.yml up api -d
 ```
 
 #### After deploy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,3 +81,18 @@ services:
   profiles:
    - update
 
+ test:
+  container_name: ops-test
+  build: .
+  environment:
+   - TESTING=True
+  volumes:
+   - ./osm:/deploy/app/osm
+   - ./osm_test:/deploy/app/osm_test
+   - ./ops_settings_docker.yml:/deploy/app/openpoiservice/server/ops_settings.yml
+   - ./categories_docker.yml:/deploy/app/openpoiservice/server/categories/categories.yml
+  depends_on:
+   - db
+  mem_limit: 8g
+  networks:
+   - poi_network

--- a/ops_settings_docker.yml
+++ b/ops_settings_docker.yml
@@ -1,4 +1,4 @@
---- 
+---
 attribution: "openrouteservice.org | OpenStreetMap contributors"
 maximum_categories: 5
 # meters

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ pycparser==2.20
 PyDispatcher==2.0.5
 PyHamcrest==2.0.2
 pyOpenSSL==20.0.1
-pyproj>=2.6.0,<3.0.0
+pyproj==3.1.0
 pyrsistent==0.17.3
 PyYAML
 queuelib==1.5.0
@@ -49,7 +49,7 @@ service-identity==18.1.0
 Shapely==1.7.1
 six==1.15.0
 SQLAlchemy==1.3.22
-Twisted==20.3.0
+Twisted==21.2.0
 voluptuous==0.12.1
 w3lib==1.22.0
 Werkzeug==1.0.1

--- a/run.sh
+++ b/run.sh
@@ -1,12 +1,16 @@
 #!/bin/sh
 if [[ ! -z "$UPDATE_DB" ]]; then
   echo "Updating POI database"
-  /ops_venv/bin/python manage.py import-data
+  python manage.py import-data
 elif [[ ! -z "$INIT_DB" ]]; then
     echo "Initializing POI database"
-    /ops_venv/bin/python manage.py drop-db
-    /ops_venv/bin/python manage.py create-db
-    /ops_venv/bin/python manage.py import-data
+    python manage.py drop-db
+    python manage.py create-db
+    python manage.py import-data
+elif [[ ! -z "$TESTING" ]]; then
+  echo "Running tests"
+  export TESTING="True"
+  python manage.py test
 else
-  /ops_venv/bin/gunicorn --config /deploy/gunicorn_config.py manage:app
+  gunicorn --config gunicorn_config.py manage:app
 fi


### PR DESCRIPTION
related to https://github.com/GIScience/openpoiservice/issues/82

Regarding the todos in the ticket:

* Python 3.9 slim base image is used. This means using Debian Buster instead of Ubuntu 18.04
* I tried to strip the build dependencies to a minimum. `nano` and `wget` could be removed. If I understand it correctly `git` and `build-essentials` are only required because `imposm-parser` is installed from source. In order to reduce the image size further, it might be possible to setup a two staged build, where the first stage would only build the parser. But actually I think the better solution would be, if someone set up a build pipeline for wheels, so it can easily be installed from PyPI.
* I didn't get why Cython was in there. It seems to work fine without it. Didn't test whether omitting the installation comes along with performance penalties, though.
* The configuration issue is still open

Along the way I had to modify some bits and pieces:

* Upgrade some dependencies in `requirements.txt` because of incompatibilities with Python 3.9 and/or Debian Buster
* In order to test for side effects of this, I added the possibility to run the tests via docker compose. This could be improved to not use the same database as the API. 
* Change the locale to `C.UTF-8` instead of `en_US.UTF-8`. I don't know too much about this but the `en_US.UTF-8` would work out of the box with Debian and `click` recommended to use this locale anyways, so I thought it be an easy solution to simply switch it.
* IMO there's no benefit in using a virtual environment in a Docker image, so I got trid of this.

---

In order to further reduce the image build size and also facilitate dependency upgrading, it would be a good idea to specificy a list of (development) dependencies along with their minimum/maximum versions and let [poetry](https://python-poetry.org/) do the rest of the job. Did you already think about that?

---

> - [x] Use a Python base image
> - [x] has a lot of unnecessary RUN statements making the final image huge
> - [ ] Use configs and OSM file as build ARG and keep exposing via volumes, so that we could host the image on dockerhub/other registry, see ORS docker as example